### PR TITLE
Fix comparisons in s-rep CPNS computation

### DIFF
--- a/ShapeVariationAnalyzer/ShapeVariationAnalyzer.py
+++ b/ShapeVariationAnalyzer/ShapeVariationAnalyzer.py
@@ -101,6 +101,8 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         #          Tab: Creation of New Classification Groups
         self.collapsibleButton_previewClassificationGroups = self.getUI('CollapsibleButton_previewClassificationGroups')
         self.pathLineEdit_previewGroups = self.getUI('pathLineEdit_previewGroups')
+        self.pathLineEdit_previewGroups.filters = ctk.ctkPathLineEdit.Files
+        self.pathLineEdit_previewGroups.nameFilters = ['*.csv']
         self.collapsibleGroupBox_previewVTKFiles = self.getUI('CollapsibleGroupBox_previewVTKFiles')
         self.checkableComboBox_ChoiceOfGroup = self.getUI('CheckableComboBox_ChoiceOfGroup')
         self.tableWidget_VTKFiles = self.getUI('tableWidget_VTKFiles')
@@ -128,7 +130,11 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
 
         self.collapsibleButton_PCA = self.getUI('collapsibleButton_PCA')
         self.pathLineEdit_CSVFilePCA = self.getUI('pathLineEdit_CSVFilePCA')  
+        self.pathLineEdit_CSVFilePCA.filters = ctk.ctkPathLineEdit.Files
+        self.pathLineEdit_CSVFilePCA.nameFilters = ['*.csv']
         self.pathLineEdit_exploration = self.getUI('pathLineEdit_exploration')
+        self.pathLineEdit_exploration.filters = ctk.ctkPathLineEdit.Files
+        self.pathLineEdit_exploration.nameFilters = ['*.json']
         self.comboBox_groupPCA = self.getUI('comboBox_groupPCA')
         self.comboBox_colorMode = self.getUI('comboBox_colorMode')
 

--- a/ShapeVariationAnalyzer/cpns/cpns.py
+++ b/ShapeVariationAnalyzer/cpns/cpns.py
@@ -79,7 +79,7 @@ class CPNS(object):
             if self.nRows is None or self.nCols is None:
                 self.nRows = nRows
                 self.nCols = nCols
-            elif nRows is not self.nRows or nCols is not self.nCols:
+            elif nRows != self.nRows or nCols != self.nCols:
                 print("nRows/nCols does not match!")
                 self.clear()
                 return False
@@ -316,7 +316,7 @@ class CPNS(object):
     def computeShape(self, CPNSScores):
         # Check dimension
         CPNSDim = CPNSScores.shape[0]
-        if CPNSDim is not self.ZComp.shape[0]:
+        if CPNSDim != self.ZComp.shape[0]:
             print("Error, input CPNS scores dimension is incorrect!")
             return None
 


### PR DESCRIPTION
There are two commits here: one smooths out some UI issues and the other fixes s-rep CPNS computation for larger populations.

The crashes running CPNS were due to using "is not" to compare integers which does not work in Python except for certain small values. 