### PR TITLE
Improve usability

### DIFF
--- a/ShapeVariationAnalyzer/Resources/UI/ShapeVariationAnalyzer.ui
+++ b/ShapeVariationAnalyzer/Resources/UI/ShapeVariationAnalyzer.ui
@@ -198,9 +198,27 @@
          <string>Selection of groups</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_5">
-         <property name="verticalSpacing">
-          <number>6</number>
-         </property>
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_CSVFileDataset">
+             <property name="text">
+              <string>CSV File dataset</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="ctkPathLineEdit" name="pathLineEdit_CSVFilePCA" native="true"/>
+           </item>
+           <item row="0" column="2">
+            <widget class="QCheckBox" name="checkBox_transformToLPS">
+             <property name="text">
+              <string>Transform to LPS</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
          <item row="1" column="0">
           <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
@@ -214,26 +232,6 @@
             <widget class="QLabel" name="label_statePCA">
              <property name="text">
               <string>Computing PCA...</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="gridLayout_3">
-           <property name="horizontalSpacing">
-            <number>6</number>
-           </property>
-           <property name="verticalSpacing">
-            <number>1</number>
-           </property>
-           <item row="0" column="1">
-            <widget class="ctkPathLineEdit" name="pathLineEdit_CSVFilePCA" native="true"/>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_CSVFileDataset">
-             <property name="text">
-              <string>CSV File dataset</string>
              </property>
             </widget>
            </item>

--- a/ShapeVariationAnalyzer/Resources/UI/ShapeVariationAnalyzer.ui
+++ b/ShapeVariationAnalyzer/Resources/UI/ShapeVariationAnalyzer.ui
@@ -15,11 +15,11 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
-    <widget class="ctkCollapsibleButton" name="CollapsibleButton_creationCSVFile">
-     <property name="text">
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton_creationCSVFile" native="true">
+     <property name="text" stdset="0">
       <string>Creation of CSV File for Classification Groups</string>
      </property>
-     <property name="checked">
+     <property name="checked" stdset="0">
       <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
@@ -44,7 +44,7 @@
           </layout>
          </item>
          <item>
-          <widget class="ctkDirectoryButton" name="DirectoryButton_creationCSVFile"/>
+          <widget class="ctkDirectoryButton" name="DirectoryButton_creationCSVFile" native="true"/>
          </item>
          <item>
           <widget class="QStackedWidget" name="stackedWidget_manageGroup">
@@ -102,11 +102,11 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="CollapsibleButton_previewClassificationGroups">
-     <property name="text">
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton_previewClassificationGroups" native="true">
+     <property name="text" stdset="0">
       <string>Preview/Update Groups</string>
      </property>
-     <property name="checked">
+     <property name="checked" stdset="0">
       <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -124,7 +124,7 @@
           </widget>
          </item>
          <item>
-          <widget class="ctkPathLineEdit" name="pathLineEdit_previewGroups"/>
+          <widget class="ctkPathLineEdit" name="pathLineEdit_previewGroups" native="true"/>
          </item>
         </layout>
        </widget>
@@ -184,11 +184,11 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="collapsibleButton_PCA">
-     <property name="text">
+    <widget class="ctkCollapsibleButton" name="collapsibleButton_PCA" native="true">
+     <property name="text" stdset="0">
       <string>PCA</string>
      </property>
-     <property name="checked">
+     <property name="checked" stdset="0">
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
@@ -228,7 +228,7 @@
             <number>1</number>
            </property>
            <item row="0" column="1">
-            <widget class="ctkPathLineEdit" name="pathLineEdit_CSVFilePCA"/>
+            <widget class="ctkPathLineEdit" name="pathLineEdit_CSVFilePCA" native="true"/>
            </item>
            <item row="0" column="0">
             <widget class="QLabel" name="label_CSVFileDataset">
@@ -247,8 +247,25 @@
         <property name="title">
          <string>PCA exploration</string>
         </property>
-        <layout class="QGridLayout" name="gridLayout_8">
-         <item row="5" column="0">
+        <layout class="QGridLayout" name="gridLayout_13">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="gridLayout_7">
+           <property name="verticalSpacing">
+            <number>1</number>
+           </property>
+           <item row="0" column="1">
+            <widget class="ctkPathLineEdit" name="pathLineEdit_exploration" native="true"/>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_json">
+             <property name="text">
+              <string>JSON File</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
           <layout class="QGridLayout" name="gridLayout_2">
            <item row="2" column="0">
             <widget class="QLabel" name="label_maxSlider">
@@ -279,7 +296,25 @@
            </item>
           </layout>
          </item>
-         <item row="8" column="0">
+         <item row="2" column="0">
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="0">
+            <widget class="QPushButton" name="pushButton_saveExploration">
+             <property name="text">
+              <string>Save Exploration</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QPushButton" name="pushButton_toggleMean">
+             <property name="text">
+              <string>Toggle Mean Shape</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="0">
           <layout class="QGridLayout" name="gridLayout_12">
            <item row="0" column="1">
             <widget class="QSpinBox" name="spinBox_numberShape">
@@ -307,7 +342,7 @@
            </item>
           </layout>
          </item>
-         <item row="10" column="0">
+         <item row="4" column="0">
           <layout class="QGridLayout" name="gridLayout_10">
            <item row="0" column="1">
             <widget class="QComboBox" name="comboBox_colorMode"/>
@@ -341,12 +376,29 @@
            </item>
           </layout>
          </item>
-         <item row="15" column="0">
+         <item row="5" column="0">
+          <layout class="QGridLayout" name="gridLayout_9">
+           <item row="2" column="1">
+            <widget class="QComboBox" name="comboBox_groupPCA"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_groupExploration">
+             <property name="text">
+              <string>Group</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="ctkColorPickerButton" name="ctkColorPickerButton_groupColor"/>
+           </item>
+          </layout>
+         </item>
+         <item row="6" column="0">
           <layout class="QGridLayout" name="gridLayout_PCAsliders">
            <item row="0" column="2">
             <widget class="QLabel" name="label_valueExploration">
              <property name="text">
-              <string>Value</string>
+              <string>Value(σ)</string>
              </property>
             </widget>
            </item>
@@ -428,78 +480,29 @@
            </item>
           </layout>
          </item>
-         <item row="11" column="0">
-          <layout class="QGridLayout" name="gridLayout_9">
-           <item row="2" column="1">
-            <widget class="QComboBox" name="comboBox_groupPCA"/>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_groupExploration">
-             <property name="text">
-              <string>Group</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2">
-            <widget class="ctkColorPickerButton" name="ctkColorPickerButton_groupColor"/>
-           </item>
-          </layout>
-         </item>
-         <item row="0" column="0" rowspan="2">
-          <layout class="QGridLayout" name="gridLayout_7">
-           <property name="verticalSpacing">
-            <number>1</number>
-           </property>
-           <item row="0" column="1">
-            <widget class="ctkPathLineEdit" name="pathLineEdit_exploration"/>
-           </item>
+         <item row="7" column="0">
+          <layout class="QGridLayout" name="gridLayout_8">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_json">
+            <widget class="QLabel" name="label_decimals">
              <property name="text">
-              <string>JSON File</string>
+              <string>Decimals</string>
              </property>
             </widget>
            </item>
-          </layout>
-         </item>
-         <item row="16" column="0">
-          <layout class="QGridLayout" name="gridLayout_13" columnstretch="0,0,0">
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="spinBox_decimals"/>
+           </item>
            <item row="0" column="2">
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string/>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QCheckBox" name="checkBox_useHiddenEigenmodes">
-             <property name="text">
-              <string>Use hidden eigenmodes</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
             <widget class="QLabel" name="label_2">
              <property name="text">
               <string/>
              </property>
             </widget>
            </item>
-          </layout>
-         </item>
-         <item row="6" column="0">
-          <layout class="QGridLayout" name="gridLayout">
-           <item row="0" column="0">
-            <widget class="QPushButton" name="pushButton_saveExploration">
+           <item row="0" column="3">
+            <widget class="QCheckBox" name="checkBox_useHiddenEigenmodes">
              <property name="text">
-              <string>Save Exploration</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QPushButton" name="pushButton_toggleMean">
-             <property name="text">
-              <string>Toggle Mean Shape</string>
+              <string>Use hidden eigenmodes</string>
              </property>
             </widget>
            </item>
@@ -1022,7 +1025,7 @@
       </size>
      </property>
     </spacer>
-    </item>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/ShapeVariationAnalyzer/ShapeVariationAnalyzer.py
+++ b/ShapeVariationAnalyzer/ShapeVariationAnalyzer.py
@@ -153,6 +153,8 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         self.spinBox_colorModeParam1=self.getUI('spinBox_colorModeParam_1')
         self.spinBox_colorModeParam2=self.getUI('spinBox_colorModeParam_2')
         self.spinBox_numberShape=self.getUI('spinBox_numberShape')
+        self.spinBox_decimals = self.getUI('spinBox_decimals')
+        self.label_decimals = self.getUI('label_decimals')
 
         self.ctkColorPickerButton_groupColor=self.getUI('ctkColorPickerButton_groupColor')
 
@@ -205,6 +207,7 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         self.spinBox_numberShape.setMinimum(100)
         self.spinBox_numberShape.setMaximum(1000000)
         self.spinBox_numberShape.setValue(10000)
+        self.spinBox_decimals.setValue(3)
 
         self.checkBox_useHiddenEigenmodes.setChecked(True)
         
@@ -241,6 +244,8 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         self.label_colorModeParam2.hide()
         self.label_numberShape.hide()
         self.spinBox_numberShape.hide()
+        self.spinBox_decimals.hide()
+        self.label_decimals.hide()
         self.checkBox_useHiddenEigenmodes.hide()
 
 
@@ -419,6 +424,8 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         self.label_colorModeParam2.hide()
         self.label_numberShape.hide()
         self.spinBox_numberShape.hide()
+        self.spinBox_decimals.hide()
+        self.label_decimals.hide()
         self.checkBox_useHiddenEigenmodes.hide()
         self.checkBox_useHiddenEigenmodes.setChecked(True)
         self.pushButton_PCA.setEnabled(False) 
@@ -1068,7 +1075,7 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
             old_num_components=len(self.PCA_sliders)
             component_to_add=num_components-len(self.PCA_sliders)
             for i in range(component_to_add):
-                self.createAndAddSlider(old_num_components+i)
+                self.createAndAddSlider(old_num_components+i, self.spinBox_decimals)
                 self.comboBox_SingleExportPC.addItem(old_num_components+i+1)
             self.updateVariancePlot(num_components)
 
@@ -1348,7 +1355,7 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
 
         # Create sliders and add the PC to the combobox for Single Export
         for i in range(sliders_number):
-            self.createAndAddSlider(i)
+            self.createAndAddSlider(i, self.spinBox_decimals)
             self.comboBox_SingleExportPC.addItem(i+1)
        
 
@@ -1388,6 +1395,8 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
 
         self.label_numberShape.show()
         self.spinBox_numberShape.show()
+        self.spinBox_decimals.show()
+        self.label_decimals.show()
 
         self.checkBox_useHiddenEigenmodes.show()
 
@@ -1417,7 +1426,7 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         self.PCA_sliders_label=list()
         self.PCA_sliders_value_label=list()
 
-    def createAndAddSlider(self,num_slider):
+    def createAndAddSlider(self,num_slider, spinbox_decimals):
         exp_ratio=self.logic.pca_exploration.getExplainedRatio()
         #create the slider
         slider =qt.QSlider(qt.Qt.Horizontal)
@@ -1431,7 +1440,10 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
        
         #create the variance ratio label
         label = qt.QLabel()
-        label.setText(str(num_slider+1)+':   '+str(round(exp_ratio[num_slider],5)*100)+'%')
+        er = round(exp_ratio[num_slider] * 100, spinbox_decimals.value)
+        if spinbox_decimals.value == 0:
+            er = round(er)
+        label.setText(str(num_slider+1)+':   '+str(er)+'%')
         label.setAlignment(qt.Qt.AlignCenter)
 
         #create the value label
@@ -1439,6 +1451,7 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         '''if num_slider==4:
             print(X)'''
         valueLabel = qt.QLabel()
+        valueLabel.setMinimumWidth(40)
         valueLabel.setText(str(round(stats.norm.isf(X),3)))
 
         #slider and label added to lists
@@ -1714,7 +1727,7 @@ class ShapeVariationAnalyzerWidget(ScriptedLoadableModuleWidget):
         table = projectionTableNode.GetTable()
         table.Initialize()
 
-        pc1,pc2=self.logic.pca_exploration.getPCAProjections()
+        pc1,pc2=self.logic.pca_exploration.getPCAProjections(normalized=True)
         labels = self.logic.pca_exploration.getPCAProjectionLabels()
 
         pc1.SetName("pc1")

--- a/ShapeVariationAnalyzer/shapepcalib.py
+++ b/ShapeVariationAnalyzer/shapepcalib.py
@@ -583,15 +583,20 @@ class pcaExplorer(object):
         return self.polydataMean
 
     #Plots
-    def getPCAProjections(self):
+    def getPCAProjections(self, normalized=False):
         X_pca = self.current_pca_model["data_projection"]
+        X_std = self.current_pca_model["data_projection_std"]
 
         pc1 = X_pca[:,0].flatten()
+        if normalized is True:
+            pc1 = pc1 / X_std[0]
         pc1 = self.generateVTKFloatFromNumpy(pc1)
         #pc1 = numpy_to_vtk(num_array=pc1, array_type=vtk.VTK_FLOAT)
 
 
         pc2 = X_pca[:,1].flatten()
+        if normalized is True:
+            pc2 = pc2 / X_std[1]
         pc2 = self.generateVTKFloatFromNumpy(pc2)
         #pc2 = numpy_to_vtk(num_array=pc2, array_type=vtk.VTK_FLOAT)
 


### PR DESCRIPTION
1. Allow changing significant figures of explained variance ratio.
2. Fix shaking sliders and values.
3. Indicate using STD for sliders values.
4. Use STD for projection plot.
5. Make models be transformed to LPS coordinates by default, which can be unchecked if users want to use RAS coordinates.  